### PR TITLE
avoid breaking change introduced by #1

### DIFF
--- a/src/AvahiMDNSManager.cpp
+++ b/src/AvahiMDNSManager.cpp
@@ -931,10 +931,10 @@ void MDNSManager::unregisterService(MDNSService &service)
 
 void MDNSManager::registerServiceBrowser(const MDNSServiceBrowser::Ptr & browser,
                                          MDNSInterfaceIndex interfaceIndex,
-                                         MDNSProto protocol,
                                          const std::string &type,
                                          const std::vector<std::string> *subtypes,
-                                         const std::string &domain)
+                                         const std::string &domain,
+                                         MDNSProto protocol)
 {
     if (type.empty())
         throw std::logic_error("type argument can't be empty");

--- a/src/BonjourMDNSManager.cpp
+++ b/src/BonjourMDNSManager.cpp
@@ -744,10 +744,10 @@ void MDNSManager::unregisterService(MDNSService &service)
 
 void MDNSManager::registerServiceBrowser(const MDNSServiceBrowser::Ptr & browser,
                                          MDNSInterfaceIndex interfaceIndex,
-                                         MDNSProto protocol, // not supported (yet)
                                          const std::string &type,
                                          const std::vector<std::string> *subtypes,
-                                         const std::string &domain)
+                                         const std::string &domain,
+                                         MDNSProto protocol) // not supported (yet)
 {
     if (type.empty())
         throw std::logic_error("type argument can't be empty");

--- a/src/DummyMDNSManager.cpp
+++ b/src/DummyMDNSManager.cpp
@@ -64,11 +64,11 @@ void MDNSManager::unregisterService(MDNSService &service)
 }
 
 void MDNSManager::registerServiceBrowser(MDNSInterfaceIndex interfaceIndex,
-                                         MDNSProto protocol,
                                          const std::string &type,
                                          const std::vector<std::string> *subtypes,
                                          const std::string &domain,
-                                         const MDNSServiceBrowser::Ptr & browser)
+                                         const MDNSServiceBrowser::Ptr & browser,
+                                         MDNSProto protocol)
 {
 }
 

--- a/src/MDNSManager.hpp
+++ b/src/MDNSManager.hpp
@@ -364,17 +364,17 @@ public:
      */
     void registerServiceBrowser(const MDNSServiceBrowser::Ptr & browser,
                                 MDNSInterfaceIndex interfaceIndex,
-                                MDNSProto protocol,
                                 const std::string &type,
-                                const std::string &domain)
+                                const std::string &domain,
+                                MDNSProto protocol = MDNS_PROTO_ANY)
     {
         // receive available service types when type is empty
         registerServiceBrowser(browser,
                                interfaceIndex,
-                               protocol,
                                type.empty() ? "_services._dns-sd._udp" : type,
                                static_cast<std::vector<std::string> *>(0),
-                               domain);
+                               domain,
+                               protocol);
     }
 
     /**
@@ -384,18 +384,18 @@ public:
      */
     void registerServiceBrowser(const MDNSServiceBrowser::Ptr & browser,
                                 MDNSInterfaceIndex interfaceIndex,
-                                MDNSProto protocol,
                                 const std::string &type,
                                 const std::vector<std::string> &subtypes,
-                                const std::string &domain)
+                                const std::string &domain,
+                                MDNSProto protocol = MDNS_PROTO_ANY)
     {
         // receive available service types when type is empty
         registerServiceBrowser(browser,
                                interfaceIndex,
-                               protocol,
                                type.empty() ? "_services._dns-sd._udp" : type,
                                &subtypes,
-                               domain);
+                               domain,
+                               protocol);
     }
 
     /**
@@ -421,10 +421,10 @@ private:
 
     void registerServiceBrowser(const MDNSServiceBrowser::Ptr & browser,
                                 MDNSInterfaceIndex interfaceIndex,
-                                MDNSProto protocol,
                                 const std::string &type,
                                 const std::vector<std::string> *subtypes,
-                                const std::string &domain);
+                                const std::string &domain,
+                                MDNSProto protocol = MDNS_PROTO_ANY);
 
     class PImpl;
     std::unique_ptr<PImpl> pimpl_;


### PR DESCRIPTION
this PR makes the change introduced by #1 non-breaking so older code
can link to post-#1 mDNSWrapper versions without code changes.